### PR TITLE
bridge.http: Exceptions, Middleware, and ResponseMapper

### DIFF
--- a/lib/src/http/http_service_provider.dart
+++ b/lib/src/http/http_service_provider.dart
@@ -10,12 +10,14 @@ class HttpServiceProvider implements ServiceProvider {
   setUp(Container container,
         Server server,
         Router router,
+        _ResponseMapper responseMapper,
         SessionManager manager) {
     this.server = server;
     this.router = router;
 
     server.attachRouter(router);
 
+    container.singleton(responseMapper);
     container.singleton(server, as: Server);
     container.singleton(router, as: Router);
     container.singleton(manager);

--- a/lib/src/http/library.dart
+++ b/lib/src/http/library.dart
@@ -1,6 +1,7 @@
 library bridge.http;
 
 import 'package:shelf/shelf.dart' as shelf;
+import 'package:shelf/src/message.dart' as shelf;
 import 'package:shelf/shelf_io.dart' as shelf_io;
 import 'package:shelf_static/shelf_static.dart' as shelf_static;
 import 'package:stack_trace/stack_trace.dart' as trace;
@@ -32,3 +33,4 @@ part 'middleware/csrf_middleware.dart';
 part 'exceptions/token_mismatch_exception.dart';
 part 'middleware/static_files_middleware.dart';
 part 'middleware/input_middleware.dart';
+part 'middleware.dart';

--- a/lib/src/http/middleware.dart
+++ b/lib/src/http/middleware.dart
@@ -1,0 +1,56 @@
+part of bridge.http;
+
+abstract class Middleware {
+  Container _container;
+  _ResponseMapper _responseMapper;
+
+  shelf.Middleware transform(Container container) {
+    _container = container;
+    _responseMapper = container.make(_ResponseMapper);
+
+    return (shelf.Handler innerHandler) {
+      return (shelf.Request request) async {
+        var handledRequest = await _request(request);
+        if (handledRequest is shelf.Response) return handledRequest;
+
+        var response;
+
+        if (handledRequest is shelf.Request) response = await innerHandler(handledRequest);
+        else response = await innerHandler(request);
+
+        return _response(response);
+      };
+    };
+  }
+
+  Future<shelf.Message> _request(shelf.Request request) async {
+    if (!_container.canResolveMethod(this, 'request')) return null;
+
+    var returnValue = await _container.resolveMethod(
+        this,
+        'request',
+        injecting: {
+          shelf.Request: request
+        });
+
+    if (returnValue == null) return null;
+    if (returnValue is shelf.Request) return returnValue;
+    return _responseMapper.valueToResponse(returnValue);
+  }
+
+  Future<shelf.Response> _response(shelf.Response response) async {
+    if (!_container.canResolveMethod(this, 'response')) return response;
+
+
+    var returnValue = await _container.resolveMethod(
+        this,
+        'response',
+        injecting: {
+          shelf.Response: response
+        });
+
+    if (returnValue == null) return response;
+    if (returnValue is shelf.Response) return returnValue;
+    return _responseMapper.valueToResponse(returnValue);
+  }
+}

--- a/lib/src/http/server.dart
+++ b/lib/src/http/server.dart
@@ -150,8 +150,12 @@ class _Server implements Server {
 
   void handleException(Type exceptionType, Function handler, {int statusCode: 500}) {
     this.addMiddleware(shelf.createMiddleware(errorHandler: (Object exception, StackTrace stack) async {
-      if (exception.runtimeType == exceptionType)
-        return _valueToResponse(await _container.resolve(handler, injecting: {Exception: exception}), statusCode);
+      if (reflectType(exception.runtimeType).isAssignableTo(reflectType(exceptionType)))
+        return _valueToResponse(await _container.resolve(handler, injecting: {
+          exceptionType: exception,
+          Exception: exception,
+          StackTrace: stack,
+        }), statusCode);
       throw exception;
     }));
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bridge
 description: Extensible end-to-end framework
 author: Emil Persson <emil.n.persson@gmail.com>
-version: 1.0.0-alpha3+1
+version: 1.0.0-alpha3+2
 homepage: http://github.com/dart-bridge/framework
 environment:
   sdk: ">=1.8.0 <2.0.0"

--- a/test/http/middleware_test.dart
+++ b/test/http/middleware_test.dart
@@ -1,0 +1,104 @@
+import 'package:testcase/testcase.dart';
+export 'package:testcase/init.dart';
+import 'package:bridge/http.dart';
+import 'package:bridge/core.dart';
+import 'package:shelf/shelf.dart' as shelf;
+import 'dart:async';
+
+class MiddlewareTest implements TestCase {
+  Container container;
+
+  setUp() {
+    container = new Container();
+  }
+
+  tearDown() {}
+
+  @test
+  it_always_contains_a_shelf_middleware() {
+    expect(
+        new RequestMiddleware().transform(container),
+        new isInstanceOf<shelf.Middleware>());
+  }
+
+  Future expectResponseBody(Middleware middleware, String body) async {
+    shelf.Middleware shelfMiddleware = middleware.transform(container);
+    shelf.Response response = await shelfMiddleware((innerHandler) {
+      return new shelf.Response.ok('pass through');
+    })(new shelf.Request('GET', new Uri.http('localhost', '/path')));
+    String responseBody = await response.readAsString();
+    expect(responseBody, equals(body));
+  }
+
+  @test
+  it_can_be_a_request_middleware_that_does_nothing() async {
+    await expectResponseBody(new RequestMiddlewareThatDoesNothing(), 'pass through');
+  }
+
+  @test
+  it_can_be_a_request_middleware_with_dependencies() async {
+    await expectResponseBody(new RequestMiddleware(), 'some external value');
+  }
+
+  @test
+  it_can_be_a_response_middleware_that_does_nothing() async {
+    await expectResponseBody(new ResponseMiddlewareThatDoesNothing(), 'pass through');
+  }
+
+  @test
+  it_can_be_a_response_middleware_with_dependencies() async {
+    await expectResponseBody(new ResponseMiddleware(), 'some external value');
+  }
+
+  @test
+  it_can_be_both() async {
+    var mock = new MockRequestResponseMiddleware();
+    await expectResponseBody(mock, 'some new value');
+    mock.verifyBothCalled();
+  }
+}
+
+class RequestMiddlewareThatDoesNothing extends Middleware {
+  request() {}
+}
+
+class Dependency {
+  String value = 'some external value';
+}
+
+class RequestMiddleware extends Middleware {
+  request(Dependency dependency) {
+    return dependency.value;
+  }
+}
+
+class ResponseMiddlewareThatDoesNothing extends Middleware {
+  response() {}
+}
+
+class ResponseMiddleware extends Middleware {
+  response(Dependency dependency) {
+    return dependency.value;
+  }
+}
+
+class MockRequestResponseMiddleware extends Middleware {
+  bool _requestCalled = false;
+  bool _responseCalled = false;
+
+  request(shelf.Request request) {
+    _requestCalled = true;
+    expect(request.url.path, equals('path'));
+  }
+
+  response(shelf.Response response) async {
+    _responseCalled = true;
+    expect(await response.readAsString(), equals('pass through'));
+    return 'some new value';
+  }
+
+  void verifyBothCalled() {
+    expect(_requestCalled, isTrue, reason: 'The middleware never received a request');
+    expect(_responseCalled, isTrue, reason: 'The middleware never received a response');
+  }
+}


### PR DESCRIPTION
- Exception handling improved
- `bridge.http.Middleware` introduced
- `bridge.http._ResponseMapper` turns anything into the correct `shelf.Response`
